### PR TITLE
dosfsck: remove MAP_POPULATE flag for mmap

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,14 @@
+fatprogs v2.13.3 - released 2022-7-18
+=====================================
+
+BUG FIXES:
+  * dosfsck: fix the incorrect media type comparison
+  * dosfsck: remove the MAP_POPULATE flag from the mmap() call
+  * dosfsck: fix the attempt to clean the volume dirty flag
+              even when using the '-n' option.
+  * dosfsck: fix volume lable check missing
+  * test: add testing script for corruted images
+
 fatprogs v2.13.0 - released 2022-7-18
 =====================================
 
@@ -13,7 +24,7 @@ NEW FEATURES:
  * dosfsdump: add option to redirect dump data to standard output.
  * dosfsck: use FOUND.XXX directory for reclaimed files.
 
-BUF FIXES:
+BUG FIXES:
  * mkdosfs: fix wrong root directory initialization.
  * dosfsck: check boot signature more strictly to distinguish from ntfs.
  * dosfsck: remove checking time field of dot/dotdot entry.

--- a/include/fat.h
+++ b/include/fat.h
@@ -17,6 +17,7 @@ typedef enum fat_select {
    replaces broken FATs and rejects invalid cluster entries. */
 void read_fat(DOS_FS *fs);
 
+void get_fat_entry(DOS_FS *fs, uint32_t cluster, uint32_t *value, void *fat);
 void get_fat(DOS_FS *fs, uint32_t cluster, uint32_t *value);
 void modify_fat(DOS_FS *fs, uint32_t cluster, uint32_t new);
 

--- a/include/io.h
+++ b/include/io.h
@@ -46,8 +46,8 @@ void fs_close(void);
 /* Determines whether the file system has changed. See fs_close. */
 int fs_changed(void);
 
-void *fs_mmap(void *hint, off_t offset, int length);
-#define fs_munmap    munmap
+void *fs_mmap(void *hint, off_t offset, size_t length);
+int fs_munmap(void *addr, size_t length);
 
 /* Print wrong data in CHNAGE lists */
 void print_changes(void);

--- a/include/version.h
+++ b/include/version.h
@@ -3,9 +3,9 @@
 
 #define VERSION_MAJOR   "2"
 #define VERSION_MIDDLE  "13"
-#define VERSION_MINOR   "2"
+#define VERSION_MINOR   "3"
 
 #define	VERSION         VERSION_MAJOR "." VERSION_MIDDLE "." VERSION_MINOR
-#define VERSION_DATE	"2023-02-27"
+#define VERSION_DATE	"2025-02-28"
 
 #endif  /* _version_h */


### PR DESCRIPTION
When mmap() is called with the MAP_POPULATE flag in certain kernel versions (specially tested on 5.4 and 6.11), the kernel does not return if the opened device is removed.
Therefore, remove the MAP_POPULATE flag and handle the SIGBUS signal that occurs when accessing the memory mapped address afterwards.