### PR TITLE
reimplement IO using sync_file_range() instead of fsync()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,8 @@
-fatprogs v2.13.3 - released 2022-7-18
+fatprogs v2.14.0 - released 2025-3-10
 =====================================
 
-BUG FIXES:
+CHANGES:
+  * io: reimplement fsync() as sync_file_range()
   * dosfsck: fix the incorrect media type comparison
   * dosfsck: remove the MAP_POPULATE flag from the mmap() call
   * dosfsck: fix the attempt to clean the volume dirty flag

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ TOPDIR := $(shell pwd)
 
 CC = gcc
 CPP = $(CC) -E
-OPTFLAGS = -O2 -fomit-frame-pointer -D_FILE_OFFSET_BITS=64
+DEFINES = -D_FILE_OFFSET_BITS=64 -DCONFIG_SYNC_FILE_RANGE
+OPTFLAGS = -O2 -fomit-frame-pointer ${DEFINES}
 WARNFLAGS = -Wall
 DEBUGFLAGS =
 CFLAGS = $(OPTFLAGS) $(WARNFLAGS) $(DEBUGFLAGS) -I$(TOPDIR)/include
@@ -26,10 +27,10 @@ distclean:
 	$(MAKE) -C src $@
 	rm -f TAGS .#* .new* \#*# *~
 
-debug: OPTFLAGS = -g -fno-omit-frame-pointer -D_FILE_OFFSET_BITS=64 -DDEBUG -pg
+debug: OPTFLAGS = -g -fno-omit-frame-pointer -DDEBUG -pg ${DEFINES}
 debug: all
 
-asan: OPTFLAGS = -g -fno-omit-frame-pointer -D_FILE_OFFSET_BITS=64 -O0 -fsanitize=address
+asan: OPTFLAGS = -g -fno-omit-frame-pointer -O0 -fsanitize=address ${DEFINES}
 asan: LDFLAGS += -fsanitize=address
 asan: all
 

--- a/include/version.h
+++ b/include/version.h
@@ -2,10 +2,10 @@
 #define _version_h
 
 #define VERSION_MAJOR   "2"
-#define VERSION_MIDDLE  "13"
-#define VERSION_MINOR   "3"
+#define VERSION_MIDDLE  "14"
+#define VERSION_MINOR   "0"
 
 #define	VERSION         VERSION_MAJOR "." VERSION_MIDDLE "." VERSION_MINOR
-#define VERSION_DATE	"2025-02-28"
+#define VERSION_DATE	"2025-03-10"
 
 #endif  /* _version_h */

--- a/tests/test_all_images.sh
+++ b/tests/test_all_images.sh
@@ -48,7 +48,7 @@ echo "====================="
 echo "Test corrupted images"
 echo "====================="
 sleep 2
-setsid /bin/bash -c "cd ${REPO_NAME} && ./script/test_fsck_verification.py ${FATPROGS_FSCK} ${DOSFSTOOLS_FSCK} ${TEST_DIR}"
+/bin/bash -c "cd ${REPO_NAME} && ./script/test_fsck_verification.py ${FATPROGS_FSCK} ${DOSFSTOOLS_FSCK} ${TEST_DIR}"
 RET=$?
 if [ $RET -ne 0 ]; then
 	echo "Failed to test for repairing corrupted images"
@@ -57,7 +57,7 @@ fi
 
 if [ ${CHECKOUT_BR} != "main" ]; then
 	echo "Delete working branch ${CHECKOUT_BR}... "
-	setsid /bin/bash -c "cd ${REPO_NAME} && git branch -D ${CHECKOUT_BR}"
+	/bin/bash -c "cd ${REPO_NAME} && git branch -D ${CHECKOUT_BR}"
 fi
 
 echo "Sucess to test corrupted images"


### PR DESCRIPTION
Reimplement IO using sync_file_range() instead of fsync() to avoid the task's status in uninterruptible sleep for long time.
I don't have confidence to do it, because it is recommended to use other filesystem(like exfat) for partition larger than 32G.

And, remove 'setsid' when actual python test script to receive signal from terminal.